### PR TITLE
xprop: improve PropStrs to handle the last string which doesn't terminat...

### DIFF
--- a/xprop/xprop.go
+++ b/xprop/xprop.go
@@ -263,5 +263,8 @@ func PropValStrs(reply *xproto.GetPropertyReply, err error) ([]string, error) {
 			sstart = i + 1
 		}
 	}
+	if sstart < int(reply.ValueLen) {
+		strs = append(strs, string(reply.Value[sstart:]))
+	}
 	return strs, nil
 }


### PR DESCRIPTION
...e with NULL

http://www.yozooffice.com/download/    this sofeware's WM_CLASS value didn't terminate with NULL, but /usr/bin/xprop handle it correctly. 
