### PR TITLE
bugfix: SubImage can return nil

### DIFF
--- a/xgraphics/xsurface.go
+++ b/xgraphics/xsurface.go
@@ -111,7 +111,9 @@ func (im *Image) XExpPaint(wid xproto.Window, x, y int) {
 // sub-image and only that sub-image.
 func (im *Image) XPaintRects(wid xproto.Window, rects ...image.Rectangle) {
 	for _, rect := range rects {
-		im.SubImage(rect).XDraw()
+		if si := im.SubImage(rect); si != nil {
+			si.XDraw()
+		}
 	}
 	im.XPaint(wid)
 }


### PR DESCRIPTION
XPaintRects leads to nil pointer dereference if it's passed non-intersecting rects.
