### PR TITLE
Improved performance of XPaintRects

### DIFF
--- a/xgraphics/xsurface.go
+++ b/xgraphics/xsurface.go
@@ -151,11 +151,9 @@ func (im *Image) xdraw(checked bool) error {
 		data = im.Pix
 	} else {
 		data = make([]uint8, width*height*4)
-		for x := im.Rect.Min.X; x < im.Rect.Max.X; x++ {
-			for y := im.Rect.Min.Y; y < im.Rect.Max.Y; y++ {
-				i := (y-im.Rect.Min.Y)*width*4 + (x-im.Rect.Min.X)*4
-				copy(data[i:i+4], im.Pix[im.PixOffset(x, y):])
-			}
+		for y := im.Rect.Min.Y; y < im.Rect.Max.Y; y++ {
+			i := (y-im.Rect.Min.Y)*width*4
+			copy(data[i:i+4*width], im.Pix[im.PixOffset(im.Rect.Min.X, y):])
 		}
 	}
 


### PR DESCRIPTION
`xgraphics.Image.xdraw` (called by `XPaintRects`) has rather poor performance when called on a subimage.

Without any change I can get it to push ~37'000'000 pixel/second. Just swapping the x and y indexes on the loop that copies to the `data` buffer I can get to ~60'000'000 pixel/second.
With the change in this commit, that calls `copy` on whole rows `xdraw` will push ~197'000'000 pixel/second, a 5x improvement on the original.
