### PR TITLE
Invoke correct callback for SelectionRequestEvent

### DIFF
--- a/xevent/eventloop.go
+++ b/xevent/eventloop.go
@@ -258,7 +258,7 @@ func processEventQueue(xu *xgbutil.XUtil, pingBefore, pingAfter chan struct{}) {
 		case xproto.SelectionRequestEvent:
 			e := SelectionRequestEvent{&event}
 			xu.TimeSet(e.Time)
-			runCallbacks(xu, e, SelectionRequest, e.Requestor)
+			runCallbacks(xu, e, SelectionRequest, e.Owner)
 		case xproto.SelectionNotifyEvent:
 			e := SelectionNotifyEvent{&event}
 			xu.TimeSet(e.Time)


### PR DESCRIPTION
SelectionRequestEvent is sent from a requestor to the selection owner.
We're the owner, thus we should run the owner's callbacks, not the
requestor's callback.