### PR TITLE
Fix issue with window pixmaps that have an empty alpha but a valid mask

### DIFF
--- a/xgraphics/new.go
+++ b/xgraphics/new.go
@@ -150,14 +150,12 @@ func NewIcccmIcon(X *xgbutil.XUtil, iconPixmap,
 			for y = r.Min.Y; y < r.Max.Y; y++ {
 				maskBgra = mximg.At(x, y).(BGRA)
 				bgra = pximg.At(x, y).(BGRA)
-				if maskBgra.A == 0 {
-					pximg.SetBGRA(x, y, BGRA{
-						B: bgra.B,
-						G: bgra.G,
-						R: bgra.R,
-						A: 0,
-					})
-				}
+				pximg.SetBGRA(x, y, BGRA{
+					B: bgra.B,
+					G: bgra.G,
+					R: bgra.R,
+					A: maskBgra.A,
+				})
 			}
 		}
 		return pximg, nil


### PR DESCRIPTION
We were finding empty images when the icon graphic used the mask to hold all alpha information. This can be tested with the window icon for XTerm.